### PR TITLE
Fix build path to template files

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,8 +150,10 @@ scenarios
 [SIPp](https://sipp.sourceforge.net/) User Agent Server scenario
 * [SipExer](docs/tasks/sipexer.md): Executes a 
 [SipExer](https://github.com/miconda/sipexer) User Agent, including WebRTC scenarios
+ * [Asterisk](docs/tasks/asterisk.md): Runs an Asterisk PBX
  * [OSS API](docs/tasks/oss-api.md): Runs a command using the OpenSIPS Solutions
 API
+ * [MySQL client](docs/tasks/mysql-client.md): Runs a MySQL Client
  * [MySQL](docs/tasks/mysql.md): Runs a MySQL Server
  * [Sleep](docs/tasks/sleep.md): Sleeps for a certain amount of time
  * [Generic](docs/tasks/generic.md): Runs a generic task/container

--- a/docs/tasks/asterisk.md
+++ b/docs/tasks/asterisk.md
@@ -1,0 +1,52 @@
+# SIPssert Testing Framework Asterisk CLI Task
+
+Task used to execute [Asterisk PBX](https://github.com/asterisk/asterisk) server.
+
+## Behavior
+
+The task runs the `Asterisk PBX` server in a `daemon` container. One may
+provide a few custom configuration files, which are by default mounted in the
+`/etc/asterisk` directory.
+
+## Defaults
+
+The variables overwritten by default by the task are:
+
+* `image`: default image to run is `yaroslavonline/asterisk`
+
+## Settings
+
+Additional settings that can be passed to the task:
+
+* `config_files`: optional, list of paths to configuration files. List item should be formed as `asterisk config:local config`. For example, if you've got a dialplan config in scenario dir, called `extensions.conf`, task `config_files` param will look like:
+
+```yaml
+config_files:
+  - "extensions.conf:extensions.conf"
+ ``` 
+
+## Example
+
+Imagine, you've got subfolder, named `asterisk`, in scenario dir. Execute an asterisk task:
+
+```yaml
+- name: Asterisk
+  type: asterisk
+  config_files:
+    - "ari.conf:asterisk/ari.conf"
+    - "http.conf:asterisk/http.conf"
+    - "keys/cert.pem:asterisk/keys/cert.pem"
+    - "keys/key.pem:asterisk/keys/key.pem"
+  ready:
+    wait: 3
+
+- name: Curl
+  image: alpine/curl 
+  args:
+    - "-f"
+    - "-k"
+    - "-I"
+    - "https://{{ asterisk_ip }}:8089/httpstatus"
+  require:
+    Ready: Asterisk
+```

--- a/docs/tasks/mysql-client.md
+++ b/docs/tasks/mysql-client.md
@@ -1,0 +1,55 @@
+# SIPssert Testing Framework MySQL Client Task
+
+Task used to run a command line mysql client.
+
+## Behavior
+
+This task is able to communicate with MySQL Server instance.
+It has two different working modes: running a batch command, or
+running a script `.sh` (executed with bash).
+
+## Defaults
+
+The variables overwritten by default by the task are:
+
+* `image`: default image to run is `opensips/mysql-client`
+
+## Settings
+
+Additional settings that can be passed to the task:
+
+* `script`: optional, a path to a `.sh` script that can be executed;
+if missing, the `mysql-client` tool is executed
+* `host`: optional, the IP of the MySQL Server to connect; if missing,
+socket `/var/run/mysqld/mysqld.sock` is used
+* `port`: optional, the port of the MySQL Server to connect; if missing,
+`3306` is used
+* `user`: optional, the user of the MySQL Server to connect; if missing,
+`root` is used
+* `password`: optional, the password of the MySQL Server to connect
+* `database`: optional, the database of the MySQL Server to connect
+* `options`: optional, additional options of the MySQL Client; options should be formatted
+
+## Example
+
+Check contacts from OpenSIPS location table
+
+scenario.yml
+```yaml
+- name: MySQL check Register
+  type: mysql-client
+  script: scripts/mysql-register.sh
+  host: 192.168.52.2
+```
+
+scripts/mysql-register.sh
+```bash
+l=$(mysql opensips -Nse 'select count(*) from location')
+if [ "$1" = "unregister" ]; then
+  [ "$l" == "0"] && exit 0
+else
+  [ "$" == "1" ] && exit 0
+fi
+echo "ERROR: number of contacts is $l"
+exit 1
+```

--- a/sipssert/tasks/asterisk.py
+++ b/sipssert/tasks/asterisk.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python
+##
+## This file is part of the SIPssert Testing Framework project
+## Copyright (C) 2023 OpenSIPS Solutions
+##
+## This program is free software: you can redistribute it and/or modify
+## it under the terms of the GNU General Public License as published by
+## the Free Software Foundation, either version 3 of the License, or
+## (at your option) any later version.
+##
+## This program is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+## GNU General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with this program. If not, see <http://www.gnu.org/licenses/>.
+##
+
+import os
+from sipssert.task import Task
+
+class AsteriskTask(Task):
+
+    default_image = "yaroslavonline/asterisk"
+    default_mount_point = "/home"
+    default_daemon = True
+
+    asterisk_config_dir = "/etc/asterisk"
+
+    def __init__(self, test_dir, config):
+        super().__init__(test_dir, config)
+
+        self.config_files = config.get("config_files")
+        if self.config_files and isinstance(self.config_files, list):
+            for item in self.config_files:
+                files = item.split(":") 
+                if len(files) == 2:
+                    self.add_volume_dir(os.path.join(test_dir, files[1]),
+                        dest=os.path.join(self.asterisk_config_dir, files[0]))
+
+# vim: tabstop=8 expandtab shiftwidth=4 softtabstop=4

--- a/sipssert/tasks/sipexer.py
+++ b/sipssert/tasks/sipexer.py
@@ -143,9 +143,13 @@ class SipExerTask(Task):
         self.logging_color = self.logging.get("color") if isinstance(self.logging, dict) else None
 
         self.target = config.get("target")
-        # self.port = config.get("port", None)
-        # if self.port:
-        #     self.port, _ = self.parse_port(self.port)
+
+        if self.template_file:
+            self.template_file = os.path.join(self.mount_point, self.template_file)
+        if self.template_body_file:
+            self.template_body_file = os.path.join(self.mount_point, self.template_body_file)
+        if self.template_fields_file:
+            self.template_fields_file = os.path.join(self.mount_point, self.template_fields_file)
 
     def get_task_args(self):
 

--- a/sipssert/tasks/sipexer.py
+++ b/sipssert/tasks/sipexer.py
@@ -144,11 +144,11 @@ class SipExerTask(Task):
 
         self.target = config.get("target")
 
-        if self.template_file:
+        if self.template_file and not os.path.isabs(self.template_file):
             self.template_file = os.path.join(self.mount_point, self.template_file)
-        if self.template_body_file:
+        if self.template_body_file and not os.path.isabs(self.template_body_file):
             self.template_body_file = os.path.join(self.mount_point, self.template_body_file)
-        if self.template_fields_file:
+        if self.template_fields_file and not os.path.isabs(self.template_fields_file):
             self.template_fields_file = os.path.join(self.mount_point, self.template_fields_file)
 
     def get_task_args(self):

--- a/sipssert/tasks/sipexer.py
+++ b/sipssert/tasks/sipexer.py
@@ -150,7 +150,7 @@ class SipExerTask(Task):
             self.template_body_file = os.path.join(self.mount_point, self.template_body_file)
         if self.template_fields_file and not os.path.isabs(self.template_fields_file):
             self.template_fields_file = os.path.join(self.mount_point, self.template_fields_file)
-
+            
     def get_task_args(self):
 
         """Returns the arguments the container uses to start"""


### PR DESCRIPTION
Some bugfix for building path to the config files.
Fixed by including os.path.join(self.mount_point, self.template_file) in order to not set absolute path.