### PR TITLE
When command or task fails, report status to the logs.

### DIFF
--- a/sipssert/task.py
+++ b/sipssert/task.py
@@ -276,7 +276,10 @@ class Task():
     def write_status(self):
         status = self.get_exit_code()
         self.write("status", str(status))
-        self.log.debug("exited with status {}".format(status))
+        if status == 0:
+            self.log.debug("exited with status {}".format(status))
+        else:
+            self.log.error(f"{self.name} exited with status {status}")
 
     def has_finished(self):
         return self.state == State.ENDED

--- a/sipssert/tasks_list.py
+++ b/sipssert/tasks_list.py
@@ -106,6 +106,8 @@ class TasksList(list):
                 tsk.finish()
                 status = int(attrs["exitCode"])
                 self.update_status(TestStatus.PASS if status == 0 else TestStatus.FAIL)
+                if status != 0:
+                    logger.slog.error(f"{name} failed with exit code {status}")
                 if tsk.daemon:
                     self.daemon_tasks.remove(tsk)
                 else:


### PR DESCRIPTION
This is to make debugging of failures easier.