### PR TITLE
Don't always print success message when operation actually fails.

### DIFF
--- a/sipssert/network/bridged.py
+++ b/sipssert/network/bridged.py
@@ -70,9 +70,11 @@ class BridgedNetwork(network.Network):
                                                    options=options)
             self.created = True
         except docker.errors.APIError as err:
-            raise BridgedNetworkOperation(f"cannot create bridged adapter {self.name}") from err
-        finally:
-            logger.slog.info("bridged adapter %s successfully created!", self.name)
+            emsg = f"cannot create bridged adapter {self.name}"
+            logger.slog.error(emsg)
+            logger.slog.exception(err)
+            raise BridgedNetworkOperation(emsg) from err
+        logger.slog.info("bridged adapter %s successfully created!", self.name)
 
 
     def destroy(self):


### PR DESCRIPTION
There seems to be a logical error that prints "bridged adapter %s successfully created" in all cases, even if the creation fails with the exception. This change fixes that as well as dumps the exception into the log to simplify post-mortem.