### PR TITLE
Add GitHub action to validate changes against OpenSIPS/sipssert-opensips-tests.

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,0 +1,23 @@
+name: Run OpenSIPS Conformance Tests
+
+on:
+  # Triggers the workflow on all push or pull request events
+  push:
+  pull_request:
+
+jobs:
+
+  test:
+
+    runs-on: ubuntu-latest
+
+    steps:
+
+    - name: Prepare SIPssert
+      uses: sobomax/SIPssert/actions/Prepare_SIPssert@main
+      with:
+        sipssert-repo: ${{ github.repository }}
+        tests-repo: OpenSIPS/sipssert-opensips-tests
+
+    - name: Run All Tests
+      uses: sobomax/SIPssert/actions/Run_All_Tests@main


### PR DESCRIPTION
This would catch any issues like the one introduced in the commit ab5cda90c2f099c5d. This is draft for now (depends on PR #16). Once the PR #16 is cleared, `uses: sobomax/SIPssert` will be replaced with `uses: OpenSIPS/SIPssert` and the PR moved into ready to merge.