### PR TITLE
Split tests into individual jobs.

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -6,10 +6,27 @@ on:
   pull_request:
 
 jobs:
+  setup-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+
+    - name: Prepare SIPssert
+      uses: OpenSIPS/SIPssert/actions/Prepare_SIPssert@main
+      with:
+        sipssert-repo: ${{ github.repository }}
+        tests-repo: OpenSIPS/sipssert-opensips-tests
+
+    - name: Read and parse YAML file
+      id: set-matrix
+      uses: ./sipssert/actions/Set_Matrix
 
   test:
-
-    runs-on: ubuntu-latest
+    needs: setup-matrix
+    strategy:
+      matrix: ${{fromJson(needs.setup-matrix.outputs.matrix)}}
+    runs-on: ${{ matrix.os }}
 
     steps:
 
@@ -19,5 +36,7 @@ jobs:
         sipssert-repo: ${{ github.repository }}
         tests-repo: OpenSIPS/sipssert-opensips-tests
 
-    - name: Run All Tests
-      uses: OpenSIPS/SIPssert/actions/Run_All_Tests@main
+    - name: Run Test
+      uses: ./sipssert/actions/Run_Test
+      with:
+        scenario: ${{ matrix.scenario }}

--- a/actions/Publish_Logs/action.yml
+++ b/actions/Publish_Logs/action.yml
@@ -1,0 +1,21 @@
+name: 'Publish Logs'
+description: 'Collect and upload logs for all scenarious'
+inputs:
+  log_name:
+    description: "Name of logs after upload"
+    default: sipssert-logs
+    required: true
+runs:
+  using: 'composite'
+  steps:
+    - name: Resolve logs path
+      run: |
+        cd tests
+        echo "LOGS_PATH=$(readlink -f logs/latest)" >> $GITHUB_ENV
+      shell: bash
+
+    - name: Publish logs
+      uses: actions/upload-artifact@v3
+      with:
+        name: ${{ inputs.log_name }}
+        path: ${{ env.LOGS_PATH }}

--- a/actions/Run_All_Tests/action.yml
+++ b/actions/Run_All_Tests/action.yml
@@ -10,16 +10,6 @@ runs:
         sh -x ./run-all.sh
       shell: bash
 
-    - name: Resolve logs path
-      if: always()
-      run: |
-        cd tests
-        echo "LOGS_PATH=$(readlink -f logs/latest)" >> $GITHUB_ENV
-      shell: bash
-
     - name: Publish logs
-      uses: actions/upload-artifact@v3
       if: always()
-      with:
-        name: sipssert-logs
-        path: ${{ env.LOGS_PATH }}
+      uses: ./sipssert/actions/Publish_Logs

--- a/actions/Run_Test/action.yml
+++ b/actions/Run_Test/action.yml
@@ -1,0 +1,20 @@
+name: 'Run Test'
+description: 'Runs specific test, resolves the logs path, and uploads the logs'
+inputs:
+  scenario:
+    description: "Name of scenario to run"
+    required: true
+runs:
+  using: 'composite'
+  steps:
+    - name: Run All Tests
+      run: |
+        cd tests
+        SETS=${{ inputs.scenario }} sh -x ./run-all.sh
+      shell: bash
+
+    - name: Publish logs
+      if: always()
+      uses: ./sipssert/actions/Publish_Logs
+      with:
+        log_name: sipssert-${{ inputs.scenario }}-logs

--- a/actions/Set_Matrix/action.yml
+++ b/actions/Set_Matrix/action.yml
@@ -1,0 +1,17 @@
+name: 'Read Job Matrix'
+description: 'Read list of scenarious to run and output matrix.'
+inputs: {}
+outputs:
+  matrix:
+    description: "The job matrix"
+    value: ${{ steps.set-matrix.outputs.matrix }}
+runs:
+  using: 'composite'
+  steps:
+    - name: Read and parse YAML file
+      id: set-matrix
+      run: |
+        echo "Reading YAML file to create matrix"
+        MATRIX=$(python3 sipssert/actions/read_matrix.py tests/matrix.yml)
+        echo "matrix=${MATRIX}" >> $GITHUB_OUTPUT
+      shell: bash

--- a/actions/read_matrix.py
+++ b/actions/read_matrix.py
@@ -1,0 +1,3 @@
+import sys, json, yaml
+
+print(json.dumps(yaml.safe_load(open(sys.argv[1]))))


### PR DESCRIPTION
This is part II of two part PR (the other part is in the [OpenSIPS/sipssert-opensips-tests repo](https://github.com/OpenSIPS/sipssert-opensips-tests/pull/8)). It basically splits one monolithic job into individual scenarios to run in parallel. This has the following benefits:

- Test complete much faster. From 30 minutes down to 6-7 minutes;
- Logs are split on per-scenario basis making debugging much easier;
- If one of many scenarios fail, it's very obviously where it fails;
- Different OS/OpenSIPS versions can be tested in parallel if needed.
- The matrix is controlled by the matrix.yml file in the root of the tests repo.

![ScreenShot1138](https://github.com/OpenSIPS/SIPssert/assets/218662/c9c3d288-eed8-4324-aee7-a24b70f493d7)
![ScreenShot1139](https://github.com/OpenSIPS/SIPssert/assets/218662/549ae338-944d-4efc-a596-4c4067f68a0a)
