### PR TITLE
Add Postgresql task type

### DIFF
--- a/sipssert/tasks/postgresql.py
+++ b/sipssert/tasks/postgresql.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python
+##
+## This file is part of the SIPssert Testing Framework project
+## Copyright (C) 2023 OpenSIPS Solutions
+##
+## This program is free software: you can redistribute it and/or modify
+## it under the terms of the GNU General Public License as published by
+## the Free Software Foundation, either version 3 of the License, or
+## (at your option) any later version.
+##
+## This program is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+## GNU General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with this program. If not, see <http://www.gnu.org/licenses/>.
+##
+
+from sipssert.task import Task
+
+class PostgresqlTask(Task):
+
+    postgresql_default_env = {"POSTGRES_PASSWORD":"postgres"}
+    default_image = "postgres"
+    default_daemon = True
+    default_mount_point = "/docker-entrypoint-initdb.d"
+
+    def get_task_env(self):
+
+        env_dict = {}
+
+        if "postgres_password" in self.config:
+            self.root_password = self.config["postgres_password"]
+
+        if self.root_password:
+            env_dict["POSTGRES_PASSWORD"] = self.root_password
+        else:
+            env_dict = self.postgresql_default_env
+
+        return env_dict
+
+# vim: tabstop=8 expandtab shiftwidth=4 softtabstop=4


### PR DESCRIPTION
# Add PostgreSQL tasks

SIPssert only supports MySQL database. I added PostgreSQL tasks in a very similar way to MySQL.
I am aware that it surely need improvement, at least documentation, please tell what to improve/fix.

As MySQL you can add a root password with `postgres_password` and every SQL files in the scenario directory will be loaded by Postgres at startup.

A simple example scenario could be :
```
---
timeout: 60

tasks:
 - name: PostgreSQL
   type: postgresql
   stop_timeout: 5
   ready:
     wait: 50

 - name: Opensips
   type: opensips
   require:
     ready: PostgreSQL
```