### PR TITLE
Add no-trace on config, test_set and scenario level

### DIFF
--- a/docs/tracing.md
+++ b/docs/tracing.md
@@ -11,3 +11,33 @@ The data that is being captured depends on the networking mode the scenario
 runs with. If it is using a `host` network adapter, then the entire traffic of
 the host is traced. Otherwise, if a `bridged` adaptor is being used, then only
 the traffic going through the bridge network device is being traced.
+
+By default tracer is always on. You can change this behavior by disabling 
+tracer on global, test_set or scenario level with desc order priority.
+Disabling tracer on global level has highest priority.
+
+
+1. To disable tracer on global level by passing command line arg, use:
+
+`-x|--no-trace` - do not trace call
+
+2. To disable tracer on global level by defining configuration parameter in config file, edit:
+
+run.yml
+```yaml
+tracer: off
+```
+
+3. To disable tracer on test_set level, edit config.yml on test_set level:
+
+config.yml
+```yaml
+tracer: off
+```
+
+4. To disable tracer on scenario level, edit scenario.yml:
+
+scenario.yml
+```yaml
+tracer: off
+```

--- a/sipssert/controller.py
+++ b/sipssert/controller.py
@@ -52,7 +52,8 @@ class Controller:
                         tests_filters.ParseTestsFilters(exclude_filters))
         self.logs_dir = args.logs_dir
         self.no_delete = args.no_delete
-        self.no_trace = args.no_trace
+        self.no_trace = not self.config.get("tracer", True) \
+                if not args.no_trace else args.no_trace
         current_date = datetime.now().strftime("%Y-%m-%d.%H:%M:%S.%f")
         self.run_logs_dir = os.path.join(self.logs_dir, current_date)
         self.link_file = os.path.join(self.logs_dir, "latest")

--- a/sipssert/scenario.py
+++ b/sipssert/scenario.py
@@ -55,7 +55,7 @@ class Scenario():
         nets = self.networks if self.networks else []
         if self.network:
             nets.append(self.network)
-        self.no_trace = self.controller.no_trace
+        self.no_trace = self.is_no_trace(test_set)
         if not self.no_trace:
             self.tracer = tracer.Tracer(self.scen_logs_dir, "capture", nets, self.name)
         self.timeout = self.config.get("timeout", 0)
@@ -78,6 +78,16 @@ class Scenario():
         """Creates current scenario logs directory"""
         if not os.path.isdir(self.scen_logs_dir):
             os.mkdir(self.scen_logs_dir)
+
+    def is_no_trace(self, test_set):
+        """Return True if scenario should not be traced"""
+        if self.controller.no_trace:
+            return True
+        if not test_set.config.get("tracer", True):
+            return True
+        if not self.config.get("tracer", True):
+            return True
+        return False
 
     def run(self):
         """Runs a scenario with all its prerequisits"""


### PR DESCRIPTION
1) Add possibility to define `tracer: off` in run.yml config
2) Add possibility to define `tracer: off` in config.yml at test_set level
3) Add possibility to define `tracer: off` in scenario.yml at scenario.yml level

4) Add description into tracing.md docs

Some examples:
Example 1. Disable tracer on certain scenarios. Set `tracer: off` on those scenarios where tracing is not needed.
Example 2. Your sipssert consists of multiple test sets. You need to disable tracing in some test set as a whole for all scenarios inside that test set. Set `tracer: off` in config.yml on test set level. Tracer will be disabled for all scenarios inside that test set.
Example 3. You need to disable tracing on global level. Set `tracer: off` in run.yml file. Remember, that tracing as a whole will be disabled. No one scenario will be traced even if you force `tracer: on` in scenario.yml due to global tracing disabling priority