### PR TITLE
Add Asterisk AMI Client Task

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ scenarios
 * [SipExer](docs/tasks/sipexer.md): Executes a 
 [SipExer](https://github.com/miconda/sipexer) User Agent, including WebRTC scenarios
  * [Asterisk](docs/tasks/asterisk.md): Runs an Asterisk PBX
+ * [AMI Client](docs/tasks/ami-client.md): Executes an Asterisk AMI Client
  * [OSS API](docs/tasks/oss-api.md): Runs a command using the OpenSIPS Solutions
 API
  * [MySQL client](docs/tasks/mysql-client.md): Runs a MySQL Client

--- a/docs/tasks/ami-client.md
+++ b/docs/tasks/ami-client.md
@@ -1,0 +1,75 @@
+# SIPssert Testing Framework Asterisk AMI Client Task
+
+Task used to run a script using the Asterisk AMI Client
+
+## Behavior
+
+The task is able to communicate with one or more Asterisk instances using the
+Pyst2 Python Library over the Asterisk AMI interface. 
+It has two different working modes: running a batch command, or
+running a script, either with the `.sh` (executed with bash), either a `.py`
+file (executed with python). 
+
+Be aware, that you should pass settings into your script on your own if you 
+any script instead of default one
+
+## Defaults
+
+The variables overwritten by default by the task are:
+
+* `image`: default image to run is [yaroslavonline/ami-client](https://github.com/man1207/ami-client.git)
+
+## Settings
+
+Additional settings that can be passed to the task:
+
+* `script`: optional, a path to a `.sh` or `.py` script that can be executed;
+if missing, [default script](https://github.com/man1207/ami-client.git) is executed
+* `asterisk_ip`: required (if script is unset), the IP of the Asterisk Server
+* `login`: required (if script is unset), the username to log in to the AMI
+* `secret`: required (if script is unset), the secret to log in to the AMI
+* `config_file`: required (if script is unset), the XML file with scenario
+
+## Example
+
+Listen AMI Events using Asterisk AMI Client Task
+
+```
+ - name: Control call
+   type: ami-client
+   script: scripts/ami-client.py
+```
+
+Listen AMI Events using Asterisk AMI Client Task using XML config
+
+```
+ - name: Control call
+   type: ami-client
+   asterisk_ip: 192.168.1.2
+   login: developer
+   secret: 12345
+   config_file: scripts/ami.xml
+```
+
+## XML config structure
+
+```xml
+<eventGroups>
+  <group>
+      <event name="event_name" type="event_type">
+        <data Header1="Value1" Header2="Value2" />
+        <regex_fields>
+          <field>Header2</field>
+        </regex_fields>
+      </event>
+  </group>
+</eventGroups>
+```
+
+* `eventGroups`: root node
+  * `group`: groups are checked by asceding order; events inside one group are checked in any order
+    * `event`: AMI event. Attributes: `name` - custom name, `type` - AMI event type (for example, PeerStatus, Newchannel etc)
+      * `data`: attributes are headers and attribute values are header values. Values may be regex strings
+        (for example, PeerStatus="Reachable" Peer="PJSIP/888")
+      * `regex_fields`: list attributes which values should be checked as regex strings instead
+        * `field`: checked field (for example, Peer)

--- a/sipssert/tasks/ami-client.py
+++ b/sipssert/tasks/ami-client.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python
+##
+## This file is part of the SIPssert Testing Framework project
+## Copyright (C) 2023 OpenSIPS Solutions
+##
+## This program is free software: you can redistribute it and/or modify
+## it under the terms of the GNU General Public License as published by
+## the Free Software Foundation, either version 3 of the License, or
+## (at your option) any later version.
+##
+## This program is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+## GNU General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with this program. If not, see <http://www.gnu.org/licenses/>.
+##
+
+import os
+from sipssert.task import Task
+
+class AmiClientTask(Task):
+
+    default_image = "yaroslavonline/ami-client"
+    default_mount_point = '/home'
+    default_daemon = True
+
+    def __init__(self, test_dir, config):
+        super().__init__(test_dir, config)
+        self.script = config.get("script")
+
+        self.asterisk_ip = self.config.get("asterisk_ip")
+        self.login = self.config.get("login")
+        self.secret = self.config.get("secret")
+
+        if self.script and not os.path.isabs(self.script):
+            self.script = os.path.join(self.mount_point, self.script)
+
+    def get_task_args(self):
+        args = []
+
+        if self.script:
+            args.append(self.script)
+        else:
+            if self.config_file:
+                args.append("--config")
+                args.append(self.config_file)
+
+            if self.asterisk_ip:
+                args.append("--asteriskip")
+                args.append(self.asterisk_ip)
+
+            if self.login:
+                args.append("--login")
+                args.append(self.login)
+
+            if self.secret:
+                args.append("--secret")
+                args.append(self.secret)
+
+        return args
+
+# vim: tabstop=8 expandtab shiftwidth=4 softtabstop=4


### PR DESCRIPTION
Add Asterisk AMI Client Task

How to use
1. You configure Asterisk Task with AMI enabled (through config file)
2. You make rules in xml for checking asterisk AMI events
3. You execute scenario with Asterisk Task and AMI Client Task described
4. Calls are performed through asterisk, and asterisk sends AMI Events into TCP connection, established by AMI Client
5. AMI Client checks events according to given rules
6. If all rules passed, Task is completed with zero code (success)

You can execute yours user-defined script, but in such a case you should pass connection parameters on your own