### PR TITLE
Add extra vars functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,8 @@ be run; if `SET` is specified, only tests within that test set are being matched
 * `-e|--exclude [SET/]TEST` - similar to `-t/--test`, but specifies the tests
 that should be excluded from the execution; if both include and exclude match
 a test, the test will not be run
+* `-E|--extra-var key=value` - set additional variable as key-value pair; you can
+set extra-var arg multiple times.
 * `-n|--no-delete` - do not delete the resources after run (**NOTICE**: you
 will have to manually delete both containers and networks)
 * `-x|--no-trace` - do not trace call

--- a/docs/config/tests-set.md
+++ b/docs/config/tests-set.md
@@ -77,6 +77,34 @@ defaults:
 Check out [Example](#example) of defining default IP and port for all OpenSIPS
 tasks.
 
+## Extra variables
+
+Extra variables can be passed from command line, and then can be used as essential 
+template variables either in `config.yml` or `define.yml` or even directly in `scenario.yml`.
+It can be useful, for example, when you want to pass secrets from your github workflow, 
+retrieved from vault storage, github environment secrets, etc, as Task env variable.
+
+```
+defaults:
+  opensips:
+    ip: 192.168.52.52
+    port: 5060
+  args:
+    - -p
+    - envsubst
+  env:
+    DB_HOST: {{ db_host }}
+    DB_PASSWORD: {{ db_password }}
+```
+
+```bash
+sipssert -E db_host=${{ secrets.MYSQL_DB_HOST }} \
+-E db_password=${{ secrets.MYSQL_DB_PASSWORD }}
+```
+
+You can pass such a way some dynamic variables from your workflow, which values can 
+depend on environment.
+
 ## Example
 
 An example of a tests set that defines the osbr0 network and uses it by

--- a/sipssert/controller.py
+++ b/sipssert/controller.py
@@ -34,9 +34,14 @@ class Controller:
     """Controller class that implements the logic"""
 
     def __init__(self, args):
+        # parse extra vars
+        extra_var_dict = {}
+        for var in args.extra_var:
+            k, v = var.split('=')
+            extra_var_dict[k] = v
         self.config_file = args.config
         try:
-            self.config = config.Config(self.config_file, None, "defines.yml")
+            self.config = config.Config(self.config_file, None, "defines.yml", template_vars=extra_var_dict)
         except config.ConfigParseError:
             raise Exception(f"could not parse {self.config_file}")
         if len(args.tests):

--- a/sipssert/main.py
+++ b/sipssert/main.py
@@ -46,6 +46,12 @@ arg_parser.add_argument('-e', '--exclude',
                         metavar='[SET/]TEST',
                         default=[])
 
+arg_parser.add_argument('-E', '--extra-var',
+                        help='Set additional variable as key=value. ' \
+                                'Can be specified multiple times',
+                        action='append',
+                        default=[])
+
 arg_parser.add_argument('-c', '--config',
                         help='Absolute path of the running config',
                         default="run.yml",


### PR DESCRIPTION
Extra variables can be passed from command line, and then can be used as essential 
template variables either in `config.yml` or `define.yml` or even directly in `scenario.yml`.
It can be useful, for example, when you want to pass secrets from your github workflow, 
retrieved from vault storage, github environment secrets, etc, as Task env variable.

```bash
sipssert -E db_host=${{ secrets.MYSQL_DB_HOST }}  -E db_password=${{ secrets.MYSQL_DB_PASSWORD }}
```

```
defaults:
  opensips:
    ip: 192.168.52.52
    port: 5060
 args:
   - -p
   - envsubst
  env:
    DB_HOST: {{ db_host }}
    DB_PASSWORD: {{ db_password }}
```