### PR TITLE
Add junit compatible reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,7 @@ The SIPssert tool also accepts as parameters the following values:
 is `logs/`)
 * `-c|--config CONFIG` - [Run Configuration](docs/config/run.md) file (Default
 is `run.yml')
+* `-j|--junit-xml` - generate junit compatible report
 * `-t|--test [SET/]TEST` - pattern that specifies which scenarios/tests should
 be run; if `SET` is specified, only tests within that test set are being matched
 * `-e|--exclude [SET/]TEST` - similar to `-t/--test`, but specifies the tests

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -74,6 +74,18 @@ Each task generates two files in the `SCENDIR` directory:
 * *`task_name`*`.log` - contains the logs of the application (fetched by the
 `docker logs` command)
 
+## JUnit report
+
+You are allowed to generate junit compatible test report in xml that can
+be read by any available junit test reporter action in GitHub. So you can set up
+your workflow by generating junit report from sipssert run and passing report
+into reporter action on your own to display test result in convinient way
+on GitHub run summary.
+
+Add `junit: yes` into `run.yml` config file or pass `--junit-xml` command-line
+parameter into sipssert command when running test to generate junit report.
+Generated report will be saved into `logs/latest` directory as `report.xml`.
+
 ## Example
 
 A common hierarchy of a run would look something like this:

--- a/setup.py
+++ b/setup.py
@@ -67,6 +67,7 @@ setup(
         'jinja2',
         'pyjwt',
         'pyaml',
+        'junit-xml',
     ],
     classifiers = [
         "Programming Language :: Python :: 3",

--- a/sipssert/junit_reporter.py
+++ b/sipssert/junit_reporter.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python
+##
+## This file is part of the SIPssert Testing Framework project
+## Copyright (C) 2023 OpenSIPS Solutions
+##
+## This program is free software: you can redistribute it and/or modify
+## it under the terms of the GNU General Public License as published by
+## the Free Software Foundation, either version 3 of the License, or
+## (at your option) any later version.
+##
+## This program is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+## GNU General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with this program. If not, see <http://www.gnu.org/licenses/>.
+##
+
+"""
+junit_reporter.py - generates junit-xml compatible report
+"""
+
+from junit_xml import TestSuite, TestCase
+from sipssert.testing import TestStatus
+
+class JUnitReporter():
+
+    """Class that generates junit-xml compatible report"""
+
+    def __init__(self, name):
+        self.name = name
+        self.test_suites = []
+
+    def __get_test_suite(self, name):
+        for test_suite in self.test_suites:
+            if test_suite.name == name:
+                return test_suite
+        return None
+
+    def __get_test_case(self, test_suite_name, name):
+        test_suite = self.__get_test_suite(test_suite_name)
+        if test_suite is None:
+            return None
+        for test_case in test_suite.test_cases:
+            if test_case.name == name:
+                return test_case
+        return None
+
+    def __add_test_suite(self, name):
+        test_suite = TestSuite(name, [])
+        self.test_suites.append(test_suite)
+        return test_suite
+
+    def __add_test_case(self, test_suite_name, name):
+        test_case = TestCase(name, classname=test_suite_name)
+        test_suite = self.__get_test_suite(test_suite_name)
+
+        if test_suite is None:
+            test_suite = self.__add_test_suite(test_suite_name)
+
+        test_suite.test_cases.append(test_case)
+        return test_case
+
+    def add_status(self, test_suite_name, name, status, elapsed_sec=0):
+        test_case = self.__get_test_case(test_suite_name, name) 
+        if test_case is None:
+            test_case = self.__add_test_case(test_suite_name, name)
+
+        if status == TestStatus.UNKN:
+            test_case.add_error_info(message="Unknown")
+        if status == TestStatus.FAIL:
+            test_case.add_failure_info(message="Failure")
+        if status == TestStatus.TOUT:
+            test_case.add_failure_info(message="Timeout")
+        if status == TestStatus.PASS:
+            pass
+
+        test_case.elapsed_sec = elapsed_sec
+
+    def skip_test_case(self, test_suite_name, name):
+        test_case = self.__get_test_case(test_suite_name, name) 
+        if test_case is None:
+            test_case = self.__add_test_case(test_suite_name, name)
+
+        test_case.add_skipped_info(message="Filtered")
+
+    def save_report(self, file_name="report.xml"):
+        with open(file_name, 'w') as f:
+            TestSuite.to_file(f, self.test_suites)
+
+# vim: tabstop=8 expandtab shiftwidth=4 softtabstop=4

--- a/sipssert/main.py
+++ b/sipssert/main.py
@@ -57,6 +57,11 @@ arg_parser.add_argument('-c', '--config',
                         default="run.yml",
                         type=os.path.abspath)
 
+arg_parser.add_argument('-x', '--no-trace',
+                        help='Do not trace call',
+                        default=False,
+                        action='store_true')
+
 arg_parser.add_argument('-l', '--logs-dir',
                         help='Absolute path of the logs dir',
                         default="logs/",
@@ -67,8 +72,8 @@ arg_parser.add_argument('-n', '--no-delete',
                         default=False,
                         action='store_true')
 
-arg_parser.add_argument('-x', '--no-trace',
-                        help='Do not trace call',
+arg_parser.add_argument('-j', '--junit-xml',
+                        help='Generate junit compatible report',
                         default=False,
                         action='store_true')
 

--- a/sipssert/scenario.py
+++ b/sipssert/scenario.py
@@ -28,6 +28,7 @@ from sipssert import logger
 from sipssert import config
 from sipssert import tracer
 from sipssert import tasks_list
+from sipssert import junit_reporter
 
 LOGS_DIR = "logs"
 NETWORK_CAP = "net_capture"
@@ -43,6 +44,8 @@ class Scenario():
         self.dirname = os.path.dirname(scenario_file)
         self.scenario = os.path.basename(scenario_file)
         self.name = os.path.basename(self.dirname)
+        self.test_set_name = test_set.name
+
         self.scen_logs_dir = os.path.join(set_logs_dir, self.name)
         try:
             self.config = config.Config(self.dirname, self.scenario, VARIABLES,
@@ -109,8 +112,11 @@ class Scenario():
             logger.slog.exception("Error occured during cleanup task")
         if not self.no_trace:
             self.tracer.stop()
-        logger.slog.debug("scenario executed in {:.3f}s".format(time.time() - start_time))
+        elapsed_sec = time.time() - start_time
+        logger.slog.debug("scenario executed in {:.3f}s".format(elapsed_sec))
         self.tlogger.status(self.tasks.status)
+        if self.controller.junit_xml:
+            self.controller.junit_reporter.add_status(self.test_set_name, self.name, self.tasks.status, elapsed_sec)
 
     def __del__(self):
         pass

--- a/sipssert/tests_set.py
+++ b/sipssert/tests_set.py
@@ -24,6 +24,7 @@ import time
 from sipssert import config
 from sipssert import scenario
 from sipssert import logger
+from sipssert import junit_reporter
 from sipssert import tasks_list
 from sipssert import tests_filters
 from sipssert.network import network
@@ -93,14 +94,16 @@ class TestsSet():
         """Constructs all the scenarios"""
         scenarios = []
         scenarios_paths = []
+
         for test in sorted(os.listdir(self.set_path)):
-            if not tests_filters.CanExecute(self.name, test, self.filters):
-                continue
             test_dir = os.path.join(self.set_path, test)
-            if os.path.isdir(test_dir):
-                if SCENARIO in os.listdir(test_dir):
-                    scenario_path = os.path.join(test_dir, SCENARIO)
-                    scenarios_paths.append(scenario_path)
+            if os.path.isdir(test_dir) and SCENARIO in os.listdir(test_dir):
+                if not tests_filters.CanExecute(self.name, test, self.filters):
+                    if self.controller.junit_xml:
+                        self.controller.junit_reporter.skip_test_case(self.name, test)
+                    continue
+                scenario_path = os.path.join(test_dir, SCENARIO)
+                scenarios_paths.append(scenario_path)
         for scenario_path in scenarios_paths:
             scenarios.append(scenario.Scenario(scenario_path, self.controller, self, self.set_logs_dir, self.defaults))
 


### PR DESCRIPTION
Hi!
Here is junit report feature.

1. Enable feature by passing `--junit-xml` as cmd-line param or put `junit: yes` into global config file
2. Report will be generated and saved into `logs/latest/report.xml`
3. Then you are allowed to pass report next into reporter action in tests workflow to print out test results summarized or detailed.
4. Excluded tasks (when you exclude or include ones in global config) will be displayed like `skipped` in report as well

Here is an example of how it can be displayed in run summary
https://github.com/man1207/SIPssert/actions/runs/12482574669/attempts/1#summary-34836934692
or in detailed
https://github.com/man1207/SIPssert/actions/runs/12482574669/job/34837079496

I don't include here commits related to actions/workflows. Only feature code.
If you wish to modify action and workflow to gain junit reports in SIPssert repo it can be performed such a way:
1) Add `--junit-xml` cmd-line param when execute `sipssert` command in action.
2) Or put `junit: yes` into global config file in `sipssert-opensips-tests` repository
3) Next take report and pass into action that displays report in run summary  (`mikepenz/action-junit-report`or `dorny/test-reporter` for instance). You can call these actions from `sipssert-opensips-tests` repo by calling `mikepenz/action-junit-report` per job and `dorny/test-reporter` for run as a whole (you must aggregate reports from artifacts in such case).

Or, if you wish, I can bring commits that generate reports in workflow run in yet another PR. Look at links above. Do you like how reports look in workflow run?